### PR TITLE
ist-14 Add Docker Compose setup for seeding test databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ To remove the volume, run:
 docker volume rm internet-speed-tracker_postgres_data
 ```
 
+To remove all services and volumes, run:
+```bash
+make docker-clean
+```
+
 ### Frontend Development with Docker Backend
 To run frontend dev server with docker backend:
 - Run `make frontend-dev` to deploy the backend and frontend services

--- a/backend/tests/utils/seed_data.sql
+++ b/backend/tests/utils/seed_data.sql
@@ -1,0 +1,26 @@
+-- Insert test speed test records if there are no records
+DO $$
+BEGIN
+    -- Check if speed_test_records table is empty
+    IF NOT EXISTS (SELECT 1 FROM speed_test_records LIMIT 1) THEN
+        -- Insert seed data only if the table is empty
+        INSERT INTO speed_test_records (timestamp, download_speed, upload_speed, latency, time_of_day, server_name, server_url)
+        VALUES
+          ('2025-03-01 08:00:00+00', 120.5, 15.3, 12.5, 'MORNING', 'Test Server 1', 'https://server1.test'),
+          ('2025-03-01 14:00:00+00', 115.2, 14.9, 13.1, 'AFTERNOON', 'Test Server 1', 'https://server1.test'),
+          ('2025-03-01 20:00:00+00', 130.9, 6.8, 4.2, 'EVENING', 'Test Server 1', 'https://server1.test'),
+          ('2025-03-02 08:00:00+00', 120.5, 15.3, 12.5, 'MORNING', 'Test Server 1', 'https://server1.test'),
+          ('2025-03-02 14:00:00+00', 115.2, 14.9, 13.1, 'AFTERNOON', 'Test Server 1', 'https://server1.test'),
+          ('2025-03-02 20:00:00+00', 130.9, 6.8, 4.2, 'EVENING', 'Test Server 1', 'https://server1.test'),
+          ('2025-03-03 08:00:00+00', 120.5, 15.3, 12.5, 'MORNING', 'Test Server 1', 'https://server1.test'),
+          ('2025-03-03 14:00:00+00', 115.2, 14.9, 13.1, 'AFTERNOON', 'Test Server 1', 'https://server1.test'),
+          ('2025-03-03 20:00:00+00', 130.9, 6.8, 4.2, 'EVENING', 'Test Server 1', 'https://server1.test'),
+          ('2025-03-04 08:00:00+00', 120.5, 15.3, 12.5, 'MORNING', 'Test Server 1', 'https://server1.test'),
+          ('2025-03-04 14:00:00+00', 115.2, 14.9, 13.1, 'AFTERNOON', 'Test Server 1', 'https://server1.test'),
+          ('2025-03-04 20:00:00+00', 130.9, 6.8, 4.2, 'EVENING', 'Test Server 1', 'https://server1.test');
+
+        RAISE NOTICE 'Inserted test data: 12 speed test records';
+    ELSE
+        RAISE NOTICE 'Speed test records already exist, skipping test data generation';
+    END IF;
+END $$;

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,26 @@
+# docker-compose.dev.yml
+services:
+  # Initialize db - create table before seeding test records (TODO: Replace with Alembic migration implementation)
+  db-init:
+    image: internet-speed-tracker-api:${VERSION}
+    depends_on:
+      db:
+        condition: service_healthy
+    command: [ "python", "-c", "from database.db_manager import DatabaseManager; DatabaseManager().init_db()" ]
+
+  # Service to create test data in test environments
+  seed-db:
+    image: postgres:16-alpine
+    volumes:
+      - ./backend/tests/utils/seed_data.sql:/docker-entrypoint-initdb.d/seed_data.sql
+    depends_on:
+      db:
+        condition: service_healthy
+      db-init:
+        condition: service_completed_successfully
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_DB=${POSTGRES_DB}
+      - PGPASSWORD=${POSTGRES_PASSWORD}
+    command: >
+      psql -h db -U ${POSTGRES_USER} -d ${POSTGRES_DB} -f /docker-entrypoint-initdb.d/seed_data.sql

--- a/makefile
+++ b/makefile
@@ -2,7 +2,7 @@
 		install-dependencies pytest-tests behave-tests python-clean-up \
 		docker-build docker-build-api docker-build-speedtest docker-build-frontend \
 		frontend-install frontend-lint \
-		frontend-dev frontend-dev-down docker-up docker-down
+		frontend-dev frontend-dev-down docker-up docker-down docker-clean
 
 # Build version
 VERSION?=1.0.0-dev
@@ -70,22 +70,27 @@ frontend-lint:
 ## Deploy Locally ##
 
 # Deploy backend in docker and frontend with npm
+# Don't need the speedtest since we're seeding db with test records
 frontend-dev:
 	@echo "Starting backend services in Docker"
-	VERSION=$(VERSION) docker compose --env-file ./backend/.env -f docker-compose.yml -f docker-compose.speedtest.yml up -d api db speedtest
+	VERSION=$(VERSION) docker compose --env-file ./backend/.env -f docker-compose.yml -f docker-compose.dev.yml up -d api db db-init seed-db
 	@echo "Starting frontend in development mode..."
 	cd frontend && npm run dev
 
 frontend-dev-down:
 	@echo "Stopping backend services..."
-	VERSION=$(VERSION) docker compose --env-file ./backend/.env -f docker-compose.yml -f docker-compose.speedtest.yml down api db speedtest
+	VERSION=$(VERSION) docker compose --env-file ./backend/.env -f docker-compose.yml -f docker-compose.dev.yml down
 
 # Deploy full containerized application
 docker-up:
 	@echo "Starting all services"
-	VERSION=$(VERSION) docker compose --env-file ./backend/.env -f docker-compose.yml -f docker-compose.speedtest.yml up
+	VERSION=$(VERSION) docker compose --env-file ./backend/.env -f docker-compose.yml -f docker-compose.speedtest.yml -f docker-compose.dev.yml up
 
 docker-down:
 	@echo "Stopping all Docker Compose services..."
-	VERSION=$(VERSION) docker compose --env-file ./backend/.env -f docker-compose.yml -f docker-compose.speedtest.yml down
+	VERSION=$(VERSION) docker compose --env-file ./backend/.env -f docker-compose.yml -f docker-compose.speedtest.yml -f docker-compose.dev.yml down
 
+# Full docker cleanup including volumes
+docker-clean:
+	@echo "Stopping all Docker Compose services and removing volumes..."
+	VERSION=$(VERSION) docker compose --env-file ./backend/.env -f docker-compose.yml -f docker-compose.speedtest.yml -f docker-compose.dev.yml down -v


### PR DESCRIPTION
- Introduced a `docker-compose.dev.yml` file to enable easier test database seeding using a PostgreSQL container
- Added a `seed-db` service with predefined seed data
- Updated the Makefile to support starting this service in development environments and removing all resources including volumes with new `docker-clean` target